### PR TITLE
fix: adding the customer address repo in a separate file

### DIFF
--- a/customer-addresses.go
+++ b/customer-addresses.go
@@ -1,0 +1,7 @@
+package shopify
+
+// CustomerAddressRepository maintains the customer addresses of a shop.
+type CustomerAddressRepository interface {
+	// Delete deletes the specified address for the specified customer
+	Delete(id int64, addressID int64) error
+}

--- a/customers.go
+++ b/customers.go
@@ -29,8 +29,3 @@ type CustomerRepository interface {
 	// Get gets customer with the provided id
 	Get(id int64) (Customer, error)
 }
-
-type CustomerAddressRepository interface {
-	// Delete deletes the specified address for the specified customer
-	Delete(id int64, addressID int64) error
-}


### PR DESCRIPTION
Adding the `CustomerAddressRepository` in its own file.