### PR TITLE
feat: get customer by query params

### DIFF
--- a/customers-constants.go
+++ b/customers-constants.go
@@ -1,0 +1,6 @@
+package shopify
+
+const (
+	// CustomerQueryTag searches by customer tag
+	CustomerQueryTag = "customer_tag"
+)

--- a/customers.go
+++ b/customers.go
@@ -28,4 +28,6 @@ type CustomerRepository interface {
 	Update(customer Customer) (Customer, error)
 	// Get gets customer with the provided id
 	Get(id int64) (Customer, error)
+	// GetByQuery gets the customer matching the query and returns the fields requested
+	GetByQuery(fields []string, query string) (Customer, error)
 }


### PR DESCRIPTION
This addition allows the retrieval of customer specific fields based on specified search query.

This functionality will help achieving the `delete customer address feature` since we now have to retrieve the customerID based on the patientID, which is stored in the Customer Tags.

[Shopify REST](https://shopify.dev/api/admin-rest/2022-10/resources/customer#get-customers-search?query=email:*@mail.example.com-examples)
