### PR TITLE
feat: fulfillment updates

### DIFF
--- a/fulfillment-orders.go
+++ b/fulfillment-orders.go
@@ -1,0 +1,52 @@
+package shopify
+
+import "time"
+
+// FulfillmentOrders is a collection of fulfillment orders
+type FulfillmentOrders []FulfillmentOrder
+
+// FulfillmentOrder is a collection of line items for an order that can be
+// fulfilled from the same location
+type FulfillmentOrder struct {
+	// ID is the ID of the fulfillment order
+	ID int64
+	// OrderID is the ID for the order that's associated with the fulfillment order
+	OrderID int64
+	// AssignedLocationID is the ID of the location assigned to do the work
+	AssignedLocationID int64
+
+	// Status is the status of the fulfillment order
+	Status string
+	// LineItems are the line items of the order to be fulfilled under this location
+	LineItems FulfillmentOrderLineItems
+
+	// CreatedAt is the date and time when the fulfillment order was created
+	CreatedAt time.Time
+	// UpdateAt is the date and time when the fulfillment order was updated
+	UpdatedAt time.Time
+}
+
+// FulfillmentOrderLineItems is a collection of fulfillment order line items
+type FulfillmentOrderLineItems []FulfillmentOrderLineItem
+
+// FulfillmentOrderLineItem is a line item in a fulfillment order
+type FulfillmentOrderLineItem struct {
+	// ID is the ID of the fulfillment order line item
+	ID int64
+	// LineItemID is the ID of the line item in the order
+	LineItemID int64
+	// VariantID is the ID of the product variant
+	VariantID int64
+	// Quantity is the total number of units to be fulfilled
+	Quantity int
+	// FulfillableQuantity is the number of remaining units to be fulfilled
+	FulfillableQuantity int
+}
+
+// FulfillmentOrderRepository manages fulfillment orders
+type FulfillmentOrderRepository interface {
+	// Get retrieves a single fulfillment order
+	Get(id int64) (FulfillmentOrder, error)
+	// List retrieves all fulfillment orders for a given order
+	List(orderID int64) (FulfillmentOrders, error)
+}

--- a/fulfillments.go
+++ b/fulfillments.go
@@ -43,7 +43,7 @@ type Fulfillment struct {
 		- confirmed: The carrier is aware of the shipment, but hasn't received it yet.
 		- in_transit: The shipment is being transported between shipping facilities on the way to its destination.
 		- out_for_delivery: The shipment is being delivered to its final destination.
-		- delivered: The shipment was succesfully delivered.
+		- delivered: The shipment was successfully delivered.
 		- failure: 	Something went wrong when pulling tracking information for the shipment, such as the tracking number was invalid or the shipment was canceled.
 	*/
 	ShipmentStatus string
@@ -51,14 +51,22 @@ type Fulfillment struct {
 	LocationID int64
 	// LineItems is a collection of historical records of each item in the fulfillment.
 	LineItems LineItems
+	// FulfillmentOrders is a required write only property describing the line items and fulfillment orders that this fulfillment fulfills.
+	//
+	// At least one fulfillment order is required when creating a fulfillment. Unless a fulfillment order has their LineItems field
+	// assigned with at least one line item and quantity, all line items of the specified fulfillment order will be fulfilled.
+	LineItemsByFulfillmentOrder FulfillmentOrders
 }
 
 // FulfillmentRepository manages fulfillments
 type FulfillmentRepository interface {
-	// Create creates a new fulfillment for an order
-	Create(orderID int64, fulfillment Fulfillment) (Fulfillment, error)
-	// Update updates the properties of a fulfillment
-	Update(orderID int64, fulfillmentID int64, update Fulfillment) (Fulfillment, error)
-	// Cancel cancels a fulfillment for a specific order
-	Cancel(orderID int64, fulfillmentID int64) error
+	// Create creates a new fulfillment against a number of fulfillment orders, with optional tracking information and
+	// customer notification
+	//
+	// LineItemsByFulfillmentOrder must be populated with at least one fulfillment order
+	Create(fulfillment Fulfillment) (Fulfillment, error)
+	// UpdateTracking updates the tracking details of a fulfillment
+	UpdateTracking(fulfillment Fulfillment) (Fulfillment, error)
+	// Cancel cancels a fulfillment
+	Cancel(fulfillmentID int64) error
 }

--- a/fulfillments.go
+++ b/fulfillments.go
@@ -10,8 +10,12 @@ type Fulfillment struct {
 	OrderID int64
 	// The name of the tracking company.
 	TrackingCompany string
+	// TrackingNumber is a tracking number provided by the shipping company.
+	TrackingNumber string
 	// TrackingNumbers is a list of tracking numbers, provided by the shipping company.
 	TrackingNumbers []string
+	// The URL of the tracking page for the fulfillment.
+	TrackingURL string
 	// The URLs of tracking pages for the fulfillment.
 	TrackingURLs []string
 	// Status is the status of the fulfillment.

--- a/shop.go
+++ b/shop.go
@@ -12,6 +12,8 @@ type Shop interface {
 	Fulfillments() FulfillmentRepository
 	// FulfillmentEvents represent tracking events that belong to a fulfillment of one or more items in an order.
 	FulfillmentEvents() FulfillmentEventRepository
+	// FulfillmentOrders represent groups of line items that can be fulfilled from the same location.
+	FulfillmentOrders() FulfillmentOrderRepository
 	// Variants represents options or versions that make up an individual product.
 	Variants() VariantRepository
 	// Products are the items that are sold by the shop.


### PR DESCRIPTION
In Shopify API version `2022-07` (becomes minimum supported version 1st April), [several Admin APIs relating to order fulfillments](https://shopify.dev/docs/api/release-notes/2022-07#fulfillment-endpoints-removed-from-the-rest-admin-api) are being removed.

This PR amends the methods in `FulfillmentRepository` to reflect [those that remain](https://shopify.dev/docs/api/admin-rest/2022-07/resources/fulfillment) in `2022-07`. Creating a fulfillment now requires info from an order's `FulfillmentOrder`s and so the `FulfillmentOrderRepository` has been added with [methods to allow their fetching](https://shopify.dev/docs/api/admin-rest/2022-07/resources/fulfillmentorder).

This should bump the package version to `2.0.0` as this is a breaking change.

## Associated PRs
- [httpshopify](https://github.com/MOHC-LTD/httpshopify/pull/104)
- [mockshopify](https://github.com/MOHC-LTD/mockshopify/pull/39)