### PR TITLE
fix: customer addresses repository missing from the shop object

### DIFF
--- a/shop.go
+++ b/shop.go
@@ -28,6 +28,8 @@ type Shop interface {
 	ProductImages() ProductImageRepository
 	// Customers are the customers in the shop
 	Customers() CustomerRepository
+	// CustomerAddresses are the customers addresses in the shop
+	CustomerAddresses() CustomerAddressRepository
 	// Metafields are the metafields associated with the shop
 	Metafields() MetafieldRepository
 	// Blogs are the blogs associated with the shop


### PR DESCRIPTION
Logic to handle customer addresses exists in both this repository and the httpshopify repository. Unfortunately, the shop Interface doesn't declare this method so it cannot be used.

This fix includes the CustomerAddressRepository so clients can use its functionality.